### PR TITLE
Missing register_rest_routes, can only find Endpoints->register_routes

### DIFF
--- a/app/Bootstrap.php
+++ b/app/Bootstrap.php
@@ -26,7 +26,7 @@ class Bootstrap
 
 	public function initRestApi() {
 		$controller = new API\Endpoints;
-		$controller->register_rest_routes();
+		$controller->register_routes();
 	}
 
 	/**


### PR DESCRIPTION
Uncaught Error: Call to undefined method Favorites\API\Endpoints::register_rest_routes()